### PR TITLE
Add recursive flag to git clone for also clone submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you are looking to create a server and are already somewhat familiar with Doc
 
 To check out this repository and get a test server fully up and running, simply run,
 ```bash
-git clone https://github.com/marius311/boinc-server-docker.git
+git clone --recursive https://github.com/marius311/boinc-server-docker.git
 cd boinc-server-docker
 docker-compose pull
 docker-compose up -d


### PR DESCRIPTION
When i try to run
`git clone https://github.com/marius311/boinc-server-docker.git`
with git 2.17.0 on windows, he clones only root repo without submodules, so when i run next step 
`docker-compose up -d`
its fails with `/bin/sh: 1: ./_autosetup: not found` because of `images/makeproject/boinc` directory is empty.
So i just want to save future developers from this errors